### PR TITLE
Release: 1.2.0 -> 1.2.0

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run release script
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: CI/release.py pr-action
+        run: CI/release.py pr-action --fail
 
 
   # Do we need this?

--- a/CI/release.py
+++ b/CI/release.py
@@ -408,13 +408,13 @@ async def pr_action(
 
         existing_release = await get_release(next_version, repo, gh)
 
-        body += f"# `v{current_version}` -> `v{next_version}`"
+        body += f"# `v{current_version}` -> `v{next_version}`\n"
 
         if existing_release is not None:
             if current_version == next_version:
                 body += (
                     "## :no_entry_sign: Merging this will not result in a new version (no `fix`, "
-                    "`feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.\n\n"
+                    "`feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.\n"
                 )
 
             else:

--- a/CI/release.py
+++ b/CI/release.py
@@ -412,12 +412,15 @@ async def pr_action(
 
         if existing_release is not None:
             if current_version == next_version:
-                body += "## :no_entry_sign: Merging this will not result in a new version (no `fix`, `feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate."
+                body += (
+                    "## :no_entry_sign: Merging this will not result in a new version (no `fix`, "
+                    "`feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.\n\n"
+                )
 
             else:
                 body += f"## :warning: **WARNING: A release for {next_version} already exists [here]({existing_release['html_url']})** :warning:"
                 body += "\n"
-                body += ":no_entry_sign: I recommend to **NOT** merge this and double check the target branch!"
+                body += ":no_entry_sign: I recommend to **NOT** merge this and double check the target branch!\n\n"
 
         if len(unparsed_commits) > 0:
             body += "\n" * 3

--- a/CI/release.py
+++ b/CI/release.py
@@ -397,9 +397,6 @@ async def pr_action(
 
         bump = evaluate_version_bump(commits)
         print("bump:", bump)
-        if bump is None:
-            print("-> nothing to do")
-            return
         next_version = get_new_version(current_version, bump)
         print("next version:", next_version)
         next_tag = f"v{next_version}"

--- a/CI/release.py
+++ b/CI/release.py
@@ -421,6 +421,8 @@ async def pr_action(
                 body += f"## :warning: **WARNING: A release for {next_version} already exists [here]({existing_release['html_url']})** :warning:"
                 body += "\n"
                 body += ":no_entry_sign: I recommend to **NOT** merge this and double check the target branch!\n\n"
+        else:
+            body += f"## Merging this PR will create a new release `v{next_version}`\n"
 
         if len(unparsed_commits) > 0:
             body += "\n" * 3
@@ -430,10 +432,6 @@ async def pr_action(
             body += "\n **Make sure these commits do not contain changes which affect the bump version!**"
 
         body += "\n\n"
-
-        body += "\n"
-
-        body += f"## Merging this PR will create a new release `v{next_version}`\n"
 
         body += "### Changelog"
 

--- a/CI/release.py
+++ b/CI/release.py
@@ -432,7 +432,7 @@ async def pr_action(
                     "## :no_entry_sign: Merging this will not result in a new version (no `fix`, "
                     "`feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.\n"
                 )
-                print("")
+                print("::warning::Merging this will not result in a new version")
 
             else:
                 exit_code = 1
@@ -445,7 +445,7 @@ async def pr_action(
                     body += (
                         f"## :warning: **WARNING**: A tag '{next_tag}' already exists"
                     )
-                    print(f"::warning::A tag '{next_tag}' already exists")
+                    print(f"::error::A tag '{next_tag}' already exists")
 
                 body += "\n"
                 body += ":no_entry_sign: I recommend to **NOT** merge this and double check the target branch!\n\n"

--- a/CI/release.py
+++ b/CI/release.py
@@ -374,6 +374,7 @@ async def get_release(tag: str, repo: str, gh: GitHubAPI):
 @app.command()
 @make_sync
 async def pr_action(
+    fail: bool = False,
     # token: str = typer.Argument(..., envvar="GH_TOKEN"),
 ):
     context = json.loads(os.environ["GITHUB_CONTEXT"])
@@ -420,6 +421,8 @@ async def pr_action(
 
         body += f"# `v{current_version}` -> `v{next_version}`\n"
 
+        exit_code = 0
+
         if existing_release is not None or existing_tag is not None:
 
             if current_version == next_version:
@@ -429,6 +432,7 @@ async def pr_action(
                 )
 
             else:
+                exit_code = 1
                 title = f":no_entry_sign: {title}"
                 if existing_release is not None:
                     body += f"## :warning: **WARNING**: A release for {next_version} already exists"
@@ -461,6 +465,9 @@ async def pr_action(
         await gh.post(
             context["event"]["pull_request"]["url"], data={"body": body, "title": title}
         )
+
+        if fail:
+            sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/CI/release.py
+++ b/CI/release.py
@@ -435,11 +435,11 @@ async def pr_action(
                 exit_code = 1
                 title = f":no_entry_sign: {title}"
                 if existing_release is not None:
-                    body += f"## :warning: **WARNING**: A release for {next_version} already exists"
+                    body += f"## :warning: **WARNING**: A release for {next_tag} already exists"
                     body += f"[here]({existing_release['html_url']})** :warning:"
                 else:
                     body += (
-                        f"## :warning: **WARNING**: A tag {next_version} already exists"
+                        f"## :warning: **WARNING**: A tag '{next_tag}' already exists"
                     )
 
                 body += "\n"

--- a/theprogram
+++ b/theprogram
@@ -12,5 +12,3 @@ echo 'HALLO'
 echo 'new feature'
 
 echo 'it now takes input: ${variable}'
-
-echo "and even more"


### PR DESCRIPTION
# `v1.2.0` -> `v1.2.0`
## :no_entry_sign: Merging this will not result in a new version (no `fix`, `feat` or breaking changes). I recommend **delaying** this PR until more changes accumulate.



## :warning: This PR contains commits which are not parseable:
 - revert: "ci: remove yaml" 6d297b811deeeb07f2f03234cf4807f4d7c7f392)
 **Make sure these commits do not contain changes which affect the bump version!**

### Changelog
### Ci
* Remove yaml (91dd319498a3383fd83f0ddf1311b09fc1bb250f)
